### PR TITLE
Fix: no longer cuts off bottom of crystal on smaller devices

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -16,13 +16,18 @@ body .malm * {
   font-weight: bolder;
 }
 body .malm img {
-  margin: 0 0 -1em 0;
+  max-width: 280px;
+  width: 80%;
+  margin-bottom: 0.5em;
 }
 body .malm p {
   text-align: center;
   font-size: 1.6em;
   color: #00affb;
-  margin: 1em;
+  margin: 0 0 1em 0;
+}
+body .malm p.reset {
+  margin: 1em 0 0 0;
 }
 body .malm .crystal {
   width: 400px;

--- a/assets/index.js
+++ b/assets/index.js
@@ -3,6 +3,31 @@ new class Malm {
     this.resetsEvery = 14; // in days
     this.timer = null;
 
+    const resize = new Event("resize");
+    window.addEventListener("resize", e => {
+      // resize crystal to fit display
+      const mixerLogo = document.querySelector(".malm img");
+      const p1 = document.querySelector(".malm p:not(.reset)");
+      const p2 = document.querySelector(".malm p.reset");
+      const newH =
+        window.outerHeight -
+        mixerLogo.scrollHeight -
+        p1.scrollHeight -
+        p2.scrollHeight;
+
+      const crystal = document.querySelector(".malm .crystal");
+      const inner = crystal.querySelector(".inner");
+
+      crystal.style.height = newH > 480 ? 400 : newH;
+      crystal.style.backgroundSize = `auto ${
+        newH > 480 ? 400 : newH - newH / 5
+      }px`;
+      inner.style.backgroundSize = `auto ${
+        newH > 480 ? 400 : newH - newH / 5
+      }px`;
+    });
+    window.dispatchEvent(resize);
+
     fetch("https://mixer.com/api/v2/levels/patronage/channels/32709/status")
       .then(res => res.json())
       .then(status => {
@@ -126,6 +151,6 @@ new class Malm {
 
     document.querySelector(".malm .reset").textContent = `${this.formatDate(
       this.reset
-    )} PT`;
+    )}`;
   }
 }();

--- a/index.html
+++ b/index.html
@@ -15,8 +15,7 @@
 
 <body>
     <div class="malm">
-        <img src="https://mixer.com/_latest/assets/images/main/logos/full.svg?d0e34ecac258140ecdf06a43ad89d56cfff3cf55"
-            height=80 />
+        <img src="https://mixer.com/_latest/assets/images/main/logos/full.svg?d0e34ecac258140ecdf06a43ad89d56cfff3cf55" />
         <p>Spark Patronage Reset</p>
         <div class="crystal">
             <div class="inner"></div>


### PR DESCRIPTION
Thanks to @Skriglitz for reporting this issue, I have now fixed it where smaller mobile devices were cutting off the bottom of the crystal, had to add a `resize` eventListener to scale the crystal to fit the view